### PR TITLE
fix: style selector class .lastResult to pt-br

### DIFF
--- a/javascript/introduction-to-js-1/first-splash/jogo-advinhe-o-numero-inicio.html
+++ b/javascript/introduction-to-js-1/first-splash/jogo-advinhe-o-numero-inicio.html
@@ -16,7 +16,7 @@
         min-width: 480px;
         margin: 0 auto;
       }
-      .lastResult {
+      .ultimoResultado {
         color: white;
         padding: 3px;
       }


### PR DESCRIPTION
# Problem with the selector translation (Issue #5)
##### (pt-br)
### Problema Encontrado
Durante a tradução dos arquivos do Inglês para Português do Brasil, um seletor de estilo ficou para trás com seu nome antigo `.lastResult` em inglês mas no mesmo arquivo um componente tenta utilizá-lo com o nome em português que não havia sido traduzido `.ultimoResultado`, como segue nas respectivas linhas do arquivo em questão na branch master sem esse PR:

https://github.com/mdn/learning-area-pt-br/blob/fe4a3f8facc6db3b1911e06bdcf00d3d9f62dfca/javascript/introduction-to-js-1/first-splash/jogo-advinhe-o-numero-inicio.html#L19
https://github.com/mdn/learning-area-pt-br/blob/fe4a3f8facc6db3b1911e06bdcf00d3d9f62dfca/javascript/introduction-to-js-1/first-splash/jogo-advinhe-o-numero-inicio.html#L38

### Solução Adotada
Basicamente optei por atualizar a declaração do seletor para o nome em português que já era esperado pelo componente <p> que utiliza essa classe, da mesma forma como foi feito em outro arquivo semelhante a esse traduzido corretamente:
https://github.com/mdn/learning-area-pt-br/blob/fe4a3f8facc6db3b1911e06bdcf00d3d9f62dfca/javascript/introduction-to-js-1/first-splash/jogo-advinhe-o-numero.html#L19